### PR TITLE
Only install types packages if the package doesn't include it's own types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.2.0 (October 31, 2021)
+
+Only try to install types packages if the package doesn't include its own types
+
 ## 1.1.3 (October 31, 2021)
 
 Fixed a bug that caused types packages to be installed on at a time

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blarn",
   "description": "A Yarn wrapper with extra functionality",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "author": "Ian Sutherland <ian@iansutherland.ca>",
   "license": "MIT",
   "repository": {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import chalk from 'chalk';
 import pacote from 'pacote';
 
@@ -17,13 +19,24 @@ const add = async (packages: string[]): Promise<void> => {
       }
 
       try {
-        await pacote.manifest(typePackage);
+        const packageJsonPath = require.resolve(path.join(pkg, 'package.json'));
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
-        typePackages.push(typePackage);
-      } catch (error) {
-        if (error.code !== 'E404') {
-          console.error(`Error finding package: ${typePackage}`);
+        if (!packageJson.types) {
+          try {
+            await pacote.manifest(typePackage);
+
+            typePackages.push(typePackage);
+          } catch (error) {
+            if (error.code !== 'E404') {
+              console.error(`Error finding package: ${typePackage}`);
+            }
+          }
+        } else {
+          console.log('package already includes types');
         }
+      } catch (error) {
+        console.error(`${chalk.red('error')} unable to read package.json: error.message`);
       }
     }
   }


### PR DESCRIPTION
Some `@types` packages are just placeholders and the real types have been moved into the project. We should first check the `types` field in `package.json` to see if the project includes types.